### PR TITLE
Filament UI invoice refactor

### DIFF
--- a/app/Actions/Sales/CreateInvoiceAction.php
+++ b/app/Actions/Sales/CreateInvoiceAction.php
@@ -43,10 +43,6 @@ class CreateInvoiceAction
                 $this->createInvoiceLineAction->execute($invoice, $lineDto);
             }
 
-            if (!empty($linesToCreate)) {
-                $invoice->invoiceLines()->createMany($linesToCreate);
-            }
-
             return $invoice;
         });
 

--- a/app/Actions/Sales/CreateInvoiceLineAction.php
+++ b/app/Actions/Sales/CreateInvoiceLineAction.php
@@ -14,7 +14,7 @@ class CreateInvoiceLineAction
     public function execute(Invoice $invoice, CreateInvoiceLineDTO $dto): InvoiceLine
     {
         $currency = $invoice->currency;
-        $unitPrice = Money::of($dto->unit_price, $currency->code);
+        $unitPrice = $dto->unit_price; // Already a Money object
 
         // 1. Perform all calculations *before* creating the model, as per our pattern.
         $subtotal = $unitPrice->multipliedBy($dto->quantity, RoundingMode::HALF_UP);

--- a/app/Actions/Sales/UpdateInvoiceAction.php
+++ b/app/Actions/Sales/UpdateInvoiceAction.php
@@ -6,11 +6,18 @@ use App\DataTransferObjects\Sales\UpdateInvoiceDTO;
 use App\Exceptions\UpdateNotAllowedException;
 use App\Models\Currency;
 use App\Models\Invoice;
+use App\Models\Tax;
+use App\Services\Accounting\LockDateService;
+use Brick\Math\RoundingMode;
 use Brick\Money\Money;
 use Illuminate\Support\Facades\DB;
 
 class UpdateInvoiceAction
 {
+    public function __construct(protected LockDateService $lockDateService)
+    {
+    }
+
     public function execute(UpdateInvoiceDTO $dto): Invoice
     {
         $invoice = $dto->invoice;
@@ -18,6 +25,8 @@ class UpdateInvoiceAction
         if ($invoice->status !== Invoice::STATUS_DRAFT) {
             throw new UpdateNotAllowedException('Cannot modify a non-draft invoice.');
         }
+
+        $this->lockDateService->enforce($invoice->company, \Carbon\Carbon::parse($dto->invoice_date));
 
         return DB::transaction(function () use ($dto, $invoice) {
             $invoice->update([
@@ -30,24 +39,40 @@ class UpdateInvoiceAction
 
             $invoice->invoiceLines()->delete();
 
-            $currencyCode = Currency::find($dto->currency_id)->code;
-            $linesToCreate = [];
+            $lines = [];
             foreach ($dto->lines as $lineDto) {
-                $linesToCreate[] = [
+                // Calculate subtotal and tax amounts
+                $unitPrice = $lineDto->unit_price;
+                $subtotal = $unitPrice->multipliedBy($lineDto->quantity, RoundingMode::HALF_UP);
+
+                $taxAmount = Money::of(0, $invoice->currency->code);
+                if ($lineDto->tax_id) {
+                    $tax = Tax::find($lineDto->tax_id);
+                    if ($tax) {
+                        $taxAmount = $subtotal->multipliedBy($tax->rate, RoundingMode::HALF_UP);
+                    }
+                }
+
+                $lines[] = new \App\Models\InvoiceLine([
                     'product_id' => $lineDto->product_id,
                     'description' => $lineDto->description,
                     'quantity' => $lineDto->quantity,
-                    'unit_price' => Money::of($lineDto->unit_price, $currencyCode),
-                    'tax_id' => $lineDto->tax_id,
+                    'unit_price' => $lineDto->unit_price,
+                    'subtotal' => $subtotal,
+                    'total_line_tax' => $taxAmount,
                     'income_account_id' => $lineDto->income_account_id,
-                ];
+                    'tax_id' => $lineDto->tax_id,
+                ]);
             }
 
-            if (!empty($linesToCreate)) {
-                $invoice->invoiceLines()->createMany($linesToCreate);
-            }
-
+            $invoice->setRelation('invoiceLines', collect($lines));
+            $invoice->calculateTotalsFromLines();
             $invoice->save();
+
+            foreach ($lines as $line) {
+                $line->invoice_id = $invoice->id;
+                $line->save();
+            }
 
             return $invoice;
         });

--- a/app/DataTransferObjects/Sales/CreateInvoiceLineDTO.php
+++ b/app/DataTransferObjects/Sales/CreateInvoiceLineDTO.php
@@ -2,12 +2,14 @@
 
 namespace App\DataTransferObjects\Sales;
 
+use Brick\Money\Money;
+
 class CreateInvoiceLineDTO
 {
     public function __construct(
         public readonly string $description,
         public readonly float $quantity,
-        public readonly string $unit_price,
+        public readonly Money $unit_price,
         public readonly int $income_account_id,
         public readonly ?int $product_id,
         public readonly ?int $tax_id,

--- a/app/DataTransferObjects/Sales/UpdateInvoiceLineDTO.php
+++ b/app/DataTransferObjects/Sales/UpdateInvoiceLineDTO.php
@@ -2,12 +2,14 @@
 
 namespace App\DataTransferObjects\Sales;
 
+use Brick\Money\Money;
+
 class UpdateInvoiceLineDTO
 {
     public function __construct(
         public readonly string $description,
         public readonly float $quantity,
-        public readonly string $unit_price,
+        public readonly Money $unit_price,
         public readonly int $income_account_id,
         public readonly ?int $product_id,
         public readonly ?int $tax_id,

--- a/app/Filament/Resources/InvoiceResource.php
+++ b/app/Filament/Resources/InvoiceResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources;
 
+use App\Filament\Forms\Components\MoneyInput;
 use App\Models\Tax;
 use Filament\Forms;
 use Filament\Tables;
@@ -14,6 +15,7 @@ use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action;
 use Illuminate\Support\Facades\Auth;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Section;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Eloquent\Builder;
 use App\Filament\Resources\InvoiceResource\Pages;
@@ -21,6 +23,7 @@ use Illuminate\Database\Eloquent\SoftDeletingScope;
 use App\Filament\Resources\InvoiceResource\RelationManagers;
 use App\Models\Account;
 use App\Models\Product;
+use App\Models\Company;
 use App\Rules\NotInLockedPeriod;
 
 class InvoiceResource extends Resource
@@ -31,63 +34,110 @@ class InvoiceResource extends Resource
 
     public static function form(Form $form): Form
     {
-        return $form
-            ->schema([
-                Forms\Components\Select::make('company_id')->relationship('company', 'name')->label(__('invoice.company'))->required(),
-                Forms\Components\Select::make('customer_id')->relationship('customer', 'name')->label(__('invoice.customer'))->required(),
-                Forms\Components\Select::make('currency_id')->relationship('currency', 'name')->label(__('invoice.currency'))->required(),
-                Forms\Components\Select::make('fiscal_position_id')->relationship('fiscalPosition', 'name')->label(__('invoice.fiscal_position')),
-                Forms\Components\DatePicker::make('invoice_date')->label(__('invoice.invoice_date'))->required()->rules([new NotInLockedPeriod()]),
-                Forms\Components\DatePicker::make('due_date')->label(__('invoice.due_date'))->required(),
-                Forms\Components\Select::make('status')
-                    ->label(__('invoice.status'))
-                    ->options(Invoice::getStatuses())
-                    ->disabled()
-                    ->dehydrated(false),
+        $company = Company::first();
 
-                Repeater::make('invoiceLines')
-                    ->label(__('invoice.invoice_lines'))
-                    ->schema([
-                        Forms\Components\Select::make('product_id')
-                            ->label(__('invoice.product'))
-                            ->searchable()
-                            ->getSearchResultsUsing(fn (string $search): array => Product::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
-                            ->getOptionLabelUsing(fn ($value): ?string => Product::find($value)?->name)
-                            ->reactive()
-                            ->afterStateUpdated(function ($state, callable $set) {
-                                if ($state) {
-                                    $product = Product::find($state);
-                                    if ($product) {
-                                        $set('description', $product->description);
-                                        $set('unit_price', $product->unit_price->getAmount()->toFloat());
-                                        $set('income_account_id', $product->income_account_id);
+        return $form->schema([
+            Section::make()
+                ->schema([
+                    Forms\Components\Select::make('company_id')
+                        ->relationship('company', 'name')
+                        ->label(__('invoice.company'))
+                        ->required()
+                        ->live()
+                        ->default($company?->id)
+                        ->afterStateUpdated(function (callable $set, $state) {
+                            $company = Company::find($state);
+                            if ($company) {
+                                $set('currency_id', $company->currency_id);
+                            }
+                        }),
+                    Forms\Components\Select::make('customer_id')
+                        ->relationship('customer', 'name')
+                        ->label(__('invoice.customer'))
+                        ->required(),
+                    Forms\Components\Select::make('currency_id')
+                        ->relationship('currency', 'name')
+                        ->label(__('invoice.currency'))
+                        ->required()
+                        ->live()
+                        ->default($company?->currency_id),
+                    Forms\Components\Select::make('fiscal_position_id')
+                        ->relationship('fiscalPosition', 'name')
+                        ->label(__('invoice.fiscal_position')),
+                    Forms\Components\DatePicker::make('invoice_date')
+                        ->label(__('invoice.invoice_date'))
+                        ->required()
+                        ->rules([new NotInLockedPeriod()]),
+                    Forms\Components\DatePicker::make('due_date')
+                        ->label(__('invoice.due_date'))
+                        ->required(),
+                    Forms\Components\Select::make('status')
+                        ->label(__('invoice.status'))
+                        ->options(Invoice::getStatuses())
+                        ->disabled()
+                        ->dehydrated(false),
+                ])
+                ->columns(2),
+
+            Section::make(__('invoice.invoice_lines'))
+                ->schema([
+                    Forms\Components\Repeater::make('invoiceLines')
+                        ->label(__('invoice.invoice_lines'))
+                        ->live()
+                        ->reorderable(true)
+                        ->minItems(1)
+                        ->schema([
+                            Forms\Components\Select::make('product_id')
+                                ->label(__('invoice.product'))
+                                ->searchable()
+                                ->getSearchResultsUsing(fn(string $search): array => Product::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
+                                ->getOptionLabelUsing(fn($value): ?string => Product::find($value)?->name)
+                                ->reactive()
+                                ->afterStateUpdated(function (callable $set, $state) {
+                                    if ($state) {
+                                        $product = Product::find($state);
+                                        if ($product) {
+                                            $set('description', $product->description);
+                                            $set('unit_price', $product->unit_price);
+                                            $set('income_account_id', $product->income_account_id);
+                                        }
                                     }
-                                }
-                            })
-                            ->columnSpan(2),
-                        Forms\Components\TextInput::make('description')->label(__('invoice.description'))->maxLength(255)->required()->columnSpan(2),
-                        Forms\Components\TextInput::make('quantity')->label(__('invoice.quantity'))->required()->numeric()->default(1)->columnSpan(1),
-                        Forms\Components\TextInput::make('unit_price')->label(__('invoice.unit_price'))->required()->numeric()->columnSpan(1),
-                        Forms\Components\Select::make('tax_id')
-                            ->label(__('invoice.tax'))
-                            ->searchable()
-                            ->getSearchResultsUsing(fn (string $search): array => Tax::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
-                            ->getOptionLabelUsing(fn ($value): ?string => Tax::find($value)?->name)
-                            ->columnSpan(1),
-                        Forms\Components\Select::make('income_account_id')
-                            ->label(__('invoice.income_account'))
-                            ->searchable()
-                            ->getSearchResultsUsing(fn (string $search): array => Account::where('type', 'Income')->where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
-                            ->getOptionLabelUsing(fn ($value): ?string => Account::find($value)?->name)
-                            ->required()
-                            ->columnSpan(2),
-                    ])
-                    ->columns(5)
-                    ->columnSpanFull(),
-
-                Forms\Components\TextInput::make('total_amount')->label(__('invoice.total_amount'))->numeric()->readOnly()->prefix(fn (callable $get) => Currency::find($get('currency_id'))?->symbol),
-                Forms\Components\TextInput::make('total_tax')->label(__('invoice.total_tax'))->numeric()->readOnly()->prefix(fn (callable $get) => Currency::find($get('currency_id'))?->symbol),
-            ]);
+                                })
+                                ->columnSpan(2),
+                            Forms\Components\TextInput::make('description')
+                                ->label(__('invoice.description'))
+                                ->maxLength(255)
+                                ->required()
+                                ->columnSpan(2),
+                            Forms\Components\TextInput::make('quantity')
+                                ->label(__('invoice.quantity'))
+                                ->required()
+                                ->numeric()
+                                ->default(1)
+                                ->columnSpan(1),
+                            MoneyInput::make('unit_price')
+                                ->label(__('invoice.unit_price'))
+                                ->currencyField('../../currency_id')
+                                ->required()
+                                ->columnSpan(1),
+                            Forms\Components\Select::make('tax_id')
+                                ->label(__('invoice.tax'))
+                                ->searchable()
+                                ->getSearchResultsUsing(fn(string $search): array => Tax::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
+                                ->getOptionLabelUsing(fn($value): ?string => Tax::find($value)?->name)
+                                ->columnSpan(1),
+                            Forms\Components\Select::make('income_account_id')
+                                ->label(__('invoice.income_account'))
+                                ->searchable()
+                                ->getSearchResultsUsing(fn(string $search): array => Account::where('type', 'Income')->where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
+                                ->getOptionLabelUsing(fn($value): ?string => Account::find($value)?->name)
+                                ->required()
+                                ->columnSpan(2),
+                        ])
+                        ->columns(5)
+                        ->columnSpanFull(),
+                ]),
+        ]);
     }
 
     public static function table(Table $table): Table

--- a/app/Filament/Resources/InvoiceResource/Pages/CreateInvoice.php
+++ b/app/Filament/Resources/InvoiceResource/Pages/CreateInvoice.php
@@ -6,8 +6,11 @@ use App\Actions\Sales\CreateInvoiceAction;
 use App\DataTransferObjects\Sales\CreateInvoiceDTO;
 use App\DataTransferObjects\Sales\CreateInvoiceLineDTO;
 use App\Filament\Resources\InvoiceResource;
+use App\Models\Currency;
+use Brick\Money\Money;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 
 class CreateInvoice extends CreateRecord
 {
@@ -15,31 +18,33 @@ class CreateInvoice extends CreateRecord
 
     protected function mutateFormDataBeforeCreate(array $data): array
     {
-        $data['invoiceLines'] = $data['invoiceLines'] ?? [];
-        return $data;
-    }
-
-    protected function handleRecordCreation(array $data): Model
-    {
+        $currency = Currency::find($data['currency_id']);
         $lineDTOs = [];
         foreach ($data['invoiceLines'] as $line) {
             $lineDTOs[] = new CreateInvoiceLineDTO(
                 description: $line['description'],
                 quantity: $line['quantity'],
-                unit_price: $line['unit_price'],
+                unit_price: Money::of($line['unit_price'], $currency->code),
                 income_account_id: $line['income_account_id'],
                 product_id: $line['product_id'] ?? null,
                 tax_id: $line['tax_id'] ?? null
             );
         }
+        $data['invoiceLines'] = $lineDTOs;
+        $data['created_by_user_id'] = Auth::id();
 
+        return $data;
+    }
+
+    protected function handleRecordCreation(array $data): Model
+    {
         $invoiceDTO = new CreateInvoiceDTO(
             company_id: $data['company_id'],
             customer_id: $data['customer_id'],
             currency_id: $data['currency_id'],
             invoice_date: $data['invoice_date'],
             due_date: $data['due_date'],
-            lines: $lineDTOs,
+            lines: $data['invoiceLines'],
             fiscal_position_id: $data['fiscal_position_id'] ?? null
         );
 

--- a/app/Filament/Resources/InvoiceResource/Pages/EditInvoice.php
+++ b/app/Filament/Resources/InvoiceResource/Pages/EditInvoice.php
@@ -9,10 +9,12 @@ use App\Filament\Resources\InvoiceResource;
 use App\Filament\Resources\PaymentResource;
 use App\Models\Invoice;
 use App\Services\InvoiceService;
+use Brick\Money\Money;
 use Filament\Actions;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Auth;
 
 class EditInvoice extends EditRecord
 {
@@ -76,20 +78,18 @@ class EditInvoice extends EditRecord
 
     protected function mutateFormDataBeforeFill(array $data): array
     {
-        $this->record->loadMissing('invoiceLines');
+        $this->record->loadMissing('invoiceLines', 'currency');
         $linesData = $this->record->invoiceLines->map(function ($line) {
             return [
                 'product_id' => $line->product_id,
                 'description' => $line->description,
                 'quantity' => $line->quantity,
-                'unit_price' => $line->unit_price?->getAmount()->toFloat(),
+                'unit_price' => $line->unit_price,
                 'tax_id' => $line->tax_id,
                 'income_account_id' => $line->income_account_id,
             ];
         })->toArray();
         $data['invoiceLines'] = $linesData;
-        $data['total_amount'] = $this->record->total_amount?->getAmount()->toFloat();
-        $data['total_tax'] = $this->record->total_tax?->getAmount()->toFloat();
         return $data;
     }
 
@@ -100,7 +100,7 @@ class EditInvoice extends EditRecord
             $lineDTOs[] = new UpdateInvoiceLineDTO(
                 description: $line['description'],
                 quantity: $line['quantity'],
-                unit_price: $line['unit_price'],
+                unit_price: Money::of($line['unit_price'], $record->currency->code),
                 income_account_id: $line['income_account_id'],
                 product_id: $line['product_id'] ?? null,
                 tax_id: $line['tax_id'] ?? null
@@ -117,6 +117,6 @@ class EditInvoice extends EditRecord
             fiscal_position_id: $data['fiscal_position_id'] ?? null
         );
 
-        return (new UpdateInvoiceAction())->execute($invoiceDTO);
+        return app(UpdateInvoiceAction::class)->execute($invoiceDTO);
     }
 }

--- a/app/Observers/InvoiceLineObserver.php
+++ b/app/Observers/InvoiceLineObserver.php
@@ -7,58 +7,28 @@ use App\Models\InvoiceLine;
 class InvoiceLineObserver
 {
     /**
-     * Handle the InvoiceLine "creating" event.
-     * This method is now empty as per our new pattern.
-     * All calculation logic is handled by CreateInvoiceLineAction.
-     */
-    public function creating(InvoiceLine $invoiceLine): void
-    {
-        $invoiceLine->loadMissing('tax', 'invoice.currency');
-        $currency = $invoiceLine->invoice->currency;
-
-        // unit_price is already a Money object thanks to the MoneyCast
-        // Calculate subtotal
-        $subtotal = $invoiceLine->unit_price->multipliedBy($invoiceLine->quantity);
-        $invoiceLine->subtotal = $subtotal;
-
-        // Calculate tax
-        if ($invoiceLine->tax) {
-            $taxRate = $invoiceLine->tax->rate;
-            $invoiceLine->total_line_tax = $subtotal->multipliedBy($taxRate);
-        } else {
-            $invoiceLine->total_line_tax = \Brick\Money\Money::of(0, $currency->code);
-        }
-    }
-
-    /**
-     * Handle the InvoiceLine "updating" event.
-     * Logic for updates should also be moved to a dedicated UpdateInvoiceLineAction.
-     * For now, we clear this to enforce the pattern for creation.
-     */
-    public function updating(InvoiceLine $invoiceLine): void
-    {
-        // This should be moved to an `UpdateInvoiceLineAction` in the future.
-        // For now, we focus on the creation pattern.
-    }
-
-
-    /**
-     * Handle the InvoiceLine "saved" (created or updated) event.
-     * This is a side effect and is the correct responsibility for an observer.
+     * Handle the InvoiceLine "saved" event.
+     * This is triggered on both creation and update.
      */
     public function saved(InvoiceLine $invoiceLine): void
     {
-        $invoiceLine->invoice->calculateTotalsFromLines();
-        $invoiceLine->invoice->saveQuietly();
+        $this->updateParentInvoiceTotals($invoiceLine);
     }
 
     /**
      * Handle the InvoiceLine "deleted" event.
-     * This is a side effect and is the correct responsibility for an observer.
      */
     public function deleted(InvoiceLine $invoiceLine): void
     {
-        $invoice = $invoiceLine->invoice()->first();
+        $this->updateParentInvoiceTotals($invoiceLine);
+    }
+
+    /**
+     * Recalculate and save the totals on the parent Invoice.
+     */
+    protected function updateParentInvoiceTotals(InvoiceLine $invoiceLine): void
+    {
+        $invoice = $invoiceLine->invoice;
         if ($invoice) {
             $invoice->calculateTotalsFromLines();
             $invoice->saveQuietly();

--- a/app/Services/InvoiceService.php
+++ b/app/Services/InvoiceService.php
@@ -103,6 +103,65 @@ class InvoiceService
     }
 
     /**
+     * Resets a posted invoice back to draft status with a detailed audit log.
+     */
+    public function resetToDraft(Invoice $invoice, User $user, string $reason): void
+    {
+        if ($invoice->status !== Invoice::STATUS_POSTED) {
+            throw new \Exception('Only posted invoices can be reset to draft.');
+        }
+
+        DB::transaction(function () use ($invoice, $user, $reason) {
+            $originalEntry = $invoice->journalEntry;
+            if (!$originalEntry) {
+                throw new \Exception('Cannot reset an invoice without a journal entry.');
+            }
+
+            // Step 1: Create a detailed audit log explaining the action.
+            \App\Models\AuditLog::create([
+                'user_id' => $user->id,
+                'event_type' => 'reset_to_draft',
+                'auditable_type' => get_class($invoice),
+                'auditable_id' => $invoice->id,
+                'description' => 'Invoice Reset to Draft: ' . $reason,
+                'old_values' => ['status' => $invoice->status],
+                'new_values' => ['status' => Invoice::STATUS_DRAFT],
+                'ip_address' => request()->ip(),
+            ]);
+
+            // Step 2: Use the service to create the reversing journal entry.
+            $this->journalEntryService->createReversal(
+                $originalEntry,
+                'Reset to Draft of Invoice ' . $invoice->invoice_number . ': ' . $reason,
+                $user
+            );
+
+            // Step 3: Store original values before clearing them
+            $originalInvoiceNumber = $invoice->invoice_number;
+            $originalPostedAt = $invoice->posted_at;
+
+            // Step 4: Add to reset log for audit trail
+            $resetLog = $invoice->reset_to_draft_log ?? [];
+            $resetLog[] = [
+                'reset_at' => now()->toISOString(),
+                'reset_by' => $user->id,
+                'reason' => $reason,
+                'original_invoice_number' => $originalInvoiceNumber,
+                'original_posted_at' => $originalPostedAt?->toISOString(),
+            ];
+
+            // Step 5: Update the invoice's status and clear posted fields.
+            $invoice->status = Invoice::STATUS_DRAFT;
+            $invoice->posted_at = null;
+            $invoice->journal_entry_id = null;
+            $invoice->invoice_number = null;
+            $invoice->reset_to_draft_log = $resetLog;
+
+            $invoice->save();
+        });
+    }
+
+    /**
      * Cancels a posted invoice by creating a reversing journal entry and a detailed audit log.
      */
     public function cancel(Invoice $invoice, User $user, string $reason): void
@@ -120,7 +179,7 @@ class InvoiceService
             }
 
             // Step 1: Create a detailed audit log explaining the action.
-            AuditLog::create([
+            \App\Models\AuditLog::create([
                 'user_id' => $user->id,
                 'event_type' => 'cancellation',
                 'auditable_type' => get_class($invoice),

--- a/database/factories/InvoiceFactory.php
+++ b/database/factories/InvoiceFactory.php
@@ -41,4 +41,13 @@ class InvoiceFactory extends Factory
             ];
         });
     }
+
+    public function withLines(int $count = 1): self
+    {
+        return $this->afterCreating(function (Invoice $invoice) use ($count) {
+            \App\Models\InvoiceLine::factory()->count($count)->create([
+                'invoice_id' => $invoice->id,
+            ]);
+        });
+    }
 }

--- a/database/factories/InvoiceLineFactory.php
+++ b/database/factories/InvoiceLineFactory.php
@@ -12,19 +12,23 @@ class InvoiceLineFactory extends Factory
 {
     public function definition(): array
     {
+        $quantity = $this->faker->numberBetween(1, 5);
+        $unitPrice = Money::of($this->faker->randomFloat(2, 25, 500), 'USD');
+        $subtotal = $unitPrice->multipliedBy($quantity);
+
         return [
             // A line should NOT create its own parent invoice. The test should provide it.
             'invoice_id' => Invoice::factory(),
             'product_id' => null, // Default to a descriptive line without a product
             'description' => $this->faker->sentence(),
-            'quantity' => $this->faker->numberBetween(1, 5),
-            'unit_price' => Money::of($this->faker->randomFloat(2, 25, 500), 'USD'),
+            'quantity' => $quantity,
+            'unit_price' => $unitPrice,
             'tax_id' => null, // Default to no tax
             // The income account should come from the product or be specified in the test.
             'income_account_id' => Account::factory()->state(['type' => 'Income']),
-            // Subtotal and tax are calculated by observers.
-            'subtotal' => Money::of($this->faker->randomFloat(2, 100, 10000), 'USD'),
-            'total_line_tax' => Money::of($this->faker->randomFloat(2, 100, 10000), 'USD'),
+            // Calculate subtotal and tax properly
+            'subtotal' => $subtotal,
+            'total_line_tax' => Money::of(0, 'USD'), // No tax by default
         ];
     }
 }

--- a/database/factories/PartnerFactory.php
+++ b/database/factories/PartnerFactory.php
@@ -42,4 +42,11 @@ class PartnerFactory extends Factory
             'type' => Partner::TYPE_VENDOR,
         ]);
     }
+
+    public function customer(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => Partner::TYPE_CUSTOMER,
+        ]);
+    }
 }

--- a/tests/Feature/AccountingWorkflowTest.php
+++ b/tests/Feature/AccountingWorkflowTest.php
@@ -138,7 +138,7 @@ test('the entire accounting workflow from setup to credit note', function () {
     $lineDto = new CreateInvoiceLineDTO(
         description: 'On-site IT Infrastructure Setup',
         quantity: 1,
-        unit_price: (string) $itInfrastructureServiceCost->getAmount()->toFloat(), // DTO expects a string
+        unit_price: $itInfrastructureServiceCost, // DTO now expects Money object
         income_account_id: $revenueAccount->id,
         product_id: null,
         tax_id: null

--- a/tests/Feature/Actions/Accounting/CreateJournalEntryForInvoiceActionTest.php
+++ b/tests/Feature/Actions/Accounting/CreateJournalEntryForInvoiceActionTest.php
@@ -27,13 +27,19 @@ test('it creates a correct journal entry for a posted invoice', function () {
         'posted_at' => now(),
         'invoice_number' => 'TEST-INV-001'
     ]);
+    $unitPrice = Money::of(100, $this->company->currency->code);
+    $subtotal = $unitPrice->multipliedBy(2);
+    $taxAmount = $subtotal->multipliedBy($tax->rate);
+
     $invoice->invoiceLines()->create([
         'product_id' => $product->id,
         'income_account_id' => $product->income_account_id,
         'description' => 'Test Product',
         'quantity' => 2,
-        'unit_price' => Money::of(100, $this->company->currency->code),
+        'unit_price' => $unitPrice,
         'tax_id' => $tax->id,
+        'subtotal' => $subtotal,
+        'total_line_tax' => $taxAmount,
     ]);
 
     // THE FIX: Refresh the invoice to get the totals calculated automatically by the observer.

--- a/tests/Feature/Filament/InvoiceResourceTest.php
+++ b/tests/Feature/Filament/InvoiceResourceTest.php
@@ -1,0 +1,199 @@
+<?php
+
+use App\Filament\Resources\InvoiceResource;
+use App\Models\Product;
+use App\Models\Invoice;
+use App\Models\Partner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Traits\WithConfiguredCompany;
+use function Pest\Livewire\livewire;
+
+uses(RefreshDatabase::class, WithConfiguredCompany::class);
+
+beforeEach(function () {
+    $this->setupWithConfiguredCompany();
+    // Acting as the authenticated user
+    $this->actingAs($this->user);
+});
+
+it('can render the list page', function () {
+    $this->get(InvoiceResource::getUrl('index'))->assertSuccessful();
+});
+
+it('can render the create page', function () {
+    $this->get(InvoiceResource::getUrl('create'))->assertSuccessful();
+});
+
+it('can create an invoice', function () {
+    /** @var \App\Models\Partner $customer */
+    $customer = Partner::factory()->customer()->create([
+        'company_id' => $this->company->id,
+    ]);
+
+    /** @var \App\Models\Product $product */
+    $product = Product::factory()->create([
+        'company_id' => $this->company->id,
+        'name' => 'Test Product Line', // Set a specific name to match the database assertion
+        'unit_price' => \Brick\Money\Money::of(100, $this->company->currency->code), // Set a specific price for predictable total
+    ]);
+
+    livewire(InvoiceResource\Pages\CreateInvoice::class)
+        ->fillForm([
+            'company_id' => $this->company->id,
+            'customer_id' => $customer->id,
+            'currency_id' => $this->company->currency_id,
+            'invoice_date' => now()->format('Y-m-d'),
+            'due_date' => now()->addDays(30)->format('Y-m-d'),
+        ])
+        ->set('data.invoiceLines', [
+            [
+                'product_id' => $product->id,
+                'description' => 'Test Product Line',
+                'quantity' => 2,
+                'unit_price' => $product->unit_price->getAmount()->toFloat(),
+                'income_account_id' => $product->income_account_id,
+                'tax_id' => null,
+            ],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('invoices', [
+        'customer_id' => $customer->id,
+        'status' => Invoice::STATUS_DRAFT,
+    ]);
+
+    $this->assertDatabaseHas('invoice_lines', [
+        'product_id' => $product->id,
+        'description' => 'Test Product Line',
+        'quantity' => 2,
+    ]);
+
+    $invoice = Invoice::first();
+    expect($invoice->total_amount->getAmount()->toFloat())->toBe(200.0);
+});
+
+it('can validate input on create', function () {
+    livewire(InvoiceResource\Pages\CreateInvoice::class)
+        ->fillForm([
+            'customer_id' => null,
+            'invoice_date' => null,
+            'due_date' => null,
+            'invoiceLines' => [],
+        ])
+        ->call('create')
+        ->assertHasFormErrors([
+            'customer_id' => 'required',
+            'invoice_date' => 'required',
+            'due_date' => 'required',
+            'invoiceLines' => 'min',
+        ]);
+});
+
+it('can render the edit page', function () {
+    $invoice = Invoice::factory()->create([
+        'company_id' => $this->company->id,
+    ]);
+
+    $this->get(InvoiceResource::getUrl('edit', ['record' => $invoice]))
+        ->assertSuccessful();
+});
+
+it('can edit an invoice', function () {
+    $invoice = Invoice::factory()->withLines(1)->create([
+        'company_id' => $this->company->id,
+    ]);
+
+    /** @var \App\Models\Partner $newCustomer */
+    $newCustomer = Partner::factory()->customer()->create([
+        'company_id' => $this->company->id,
+    ]);
+
+    // The mutateFormDataBeforeFill method in EditInvoice already handles
+    // the conversion of line data with Money objects properly, so we don't need to override it
+    livewire(InvoiceResource\Pages\EditInvoice::class, [
+        'record' => $invoice->getRouteKey(),
+    ])
+        ->fillForm([
+            'customer_id' => $newCustomer->id,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('invoices', [
+        'id' => $invoice->id,
+        'customer_id' => $newCustomer->id,
+    ]);
+});
+
+it('can confirm an invoice', function () {
+    $invoice = Invoice::factory()->withLines(1)->create([
+        'company_id' => $this->company->id,
+        'status' => Invoice::STATUS_DRAFT,
+    ]);
+
+    livewire(InvoiceResource\Pages\EditInvoice::class, [
+        'record' => $invoice->getRouteKey(),
+    ])
+        ->callAction('confirm')
+        ->assertHasNoErrors();
+
+    $invoice->refresh();
+    expect($invoice->status)->toBe(Invoice::STATUS_POSTED);
+});
+
+it('can reset an invoice to draft', function () {
+    // Create accounts for the journal entry
+    $receivableAccount = \App\Models\Account::factory()->create([
+        'company_id' => $this->company->id,
+        'type' => 'Asset',
+        'name' => 'Accounts Receivable',
+    ]);
+
+    $salesAccount = \App\Models\Account::factory()->create([
+        'company_id' => $this->company->id,
+        'type' => 'Income',
+        'name' => 'Sales Revenue',
+    ]);
+
+    // Create a proper journal entry with lines for the invoice
+    $journalEntry = \App\Models\JournalEntry::factory()->create([
+        'company_id' => $this->company->id,
+        'is_posted' => true,
+    ]);
+
+    // Add lines to the journal entry
+    $journalEntry->lines()->create([
+        'account_id' => $receivableAccount->id,
+        'debit' => \Brick\Money\Money::of(100, $this->company->currency->code),
+        'credit' => \Brick\Money\Money::of(0, $this->company->currency->code),
+        'description' => 'Test line',
+    ]);
+
+    $journalEntry->lines()->create([
+        'account_id' => $salesAccount->id,
+        'debit' => \Brick\Money\Money::of(0, $this->company->currency->code),
+        'credit' => \Brick\Money\Money::of(100, $this->company->currency->code),
+        'description' => 'Test line 2',
+    ]);
+
+    $invoice = Invoice::factory()->withLines(1)->create([
+        'company_id' => $this->company->id,
+        'status' => Invoice::STATUS_POSTED,
+        'posted_at' => now(),
+        'invoice_number' => 'INV-00001',
+        'journal_entry_id' => $journalEntry->id,
+    ]);
+
+    $response = livewire(InvoiceResource\Pages\EditInvoice::class, [
+        'record' => $invoice->getRouteKey(),
+    ])
+        ->callAction('resetToDraft', data: [
+            'reason' => 'Test reason',
+        ]);
+
+    $response->assertHasNoErrors();
+
+    $invoice->refresh();
+    expect($invoice->status)->toBe(Invoice::STATUS_DRAFT);
+});

--- a/tests/Feature/FinancialTransactions/InvoiceReversalTest.php
+++ b/tests/Feature/FinancialTransactions/InvoiceReversalTest.php
@@ -1,15 +1,10 @@
 <?php
 
-use App\Models\User;
-use Brick\Money\Money;
-use App\Models\Account;
 use App\Actions\Sales\CreateInvoiceLineAction;
 use App\DataTransferObjects\Sales\CreateInvoiceLineDTO;
 use App\Models\Invoice;
 use Tests\Traits\MocksTime;
 use App\Services\InvoiceService;
-use Tests\Traits\CreatesApplication;
-use Tests\Traits\WithUnlockedPeriod;
 use Tests\Traits\WithConfiguredCompany;
 use App\Enums\Accounting\JournalEntryState;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -23,7 +18,7 @@ test('cancelling a posted invoice creates a reversing journal entry and an audit
     $lineDto = new CreateInvoiceLineDTO(
         description: 'Consulting Services',
         quantity: 1,
-        unit_price: '2500',
+        unit_price: \Brick\Money\Money::of('2500', $this->company->currency->code),
         income_account_id: $incomeAccount->id,
         product_id: null,
         tax_id: null,

--- a/tests/Feature/FinancialTransactions/InvoicesTest.php
+++ b/tests/Feature/FinancialTransactions/InvoicesTest.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Facades\Event;
 use App\Enums\Accounting\LockDateType;
 use Tests\Traits\WithConfiguredCompany;
 use App\Actions\Sales\CreateInvoiceAction;
-use App\Actions\Sales\UpdateInvoiceAction;
+
 use App\Actions\Sales\CreateInvoiceLineAction;
 use App\DataTransferObjects\Sales\CreateInvoiceLineDTO;
 use App\Exceptions\PeriodIsLockedException;
@@ -82,7 +82,7 @@ test('confirming an invoice generates the correct journal entry', function () {
         product_id: $product->id,
         description: 'Product Description',
         quantity: 2,
-        unit_price: '100',
+        unit_price: \Brick\Money\Money::of('100', $this->company->currency->code),
         income_account_id: $productSalesAccount->id,
         tax_id: null,
     );
@@ -117,7 +117,7 @@ test('a posted invoice cannot be updated', function () {
     );
 
     // Assert: Expect the Action to throw the exception because the invoice is posted.
-    expect(fn() => (new UpdateInvoiceAction())->execute($updateDto))
+    expect(fn() => app(\App\Actions\Sales\UpdateInvoiceAction::class)->execute($updateDto))
         ->toThrow(UpdateNotAllowedException::class, 'Cannot modify a non-draft invoice.');
 
     // Assert: Double-check that the customer_id was not changed in the database.


### PR DESCRIPTION
- Removed redundant invoice line creation logic from CreateInvoiceAction.
- Updated CreateInvoiceLineAction to accept Money objects directly for unit prices.
- Enhanced UpdateInvoiceAction to calculate subtotals and taxes directly within the action.
- Modified CreateInvoiceLineDTO and UpdateInvoiceLineDTO to use Money objects for unit prices.
- Improved InvoiceResource form to utilize MoneyInput for unit prices.
- Added validation and handling for invoice creation and editing in the respective pages.
- Implemented a resetToDraft method in InvoiceService for handling invoice status changes.
- Updated tests to reflect changes in DTOs and ensure proper handling of Money objects.
- Added new tests for InvoiceResource to validate creation and editing functionalities.