### PR TITLE
Refactor adjustment document handling to use Money objects directly

### DIFF
--- a/app/Actions/Adjustments/CreateAdjustmentDocumentAction.php
+++ b/app/Actions/Adjustments/CreateAdjustmentDocumentAction.php
@@ -47,7 +47,7 @@ class CreateAdjustmentDocumentAction
                     'product_id' => $lineDto->product_id,
                     'description' => $lineDto->description,
                     'quantity' => $lineDto->quantity,
-                    'unit_price' => Money::of($lineDto->unit_price, $currencyCode),
+                    'unit_price' => $lineDto->unit_price, // Already a Money object from DTO
                     'tax_id' => $lineDto->tax_id,
                     'account_id' => $lineDto->account_id,
                 ];

--- a/app/Actions/Adjustments/UpdateAdjustmentDocumentAction.php
+++ b/app/Actions/Adjustments/UpdateAdjustmentDocumentAction.php
@@ -5,8 +5,6 @@ namespace App\Actions\Adjustments;
 use App\DataTransferObjects\Adjustments\UpdateAdjustmentDocumentDTO;
 use App\Exceptions\UpdateNotAllowedException;
 use App\Models\AdjustmentDocument;
-use App\Models\Currency;
-use Brick\Money\Money;
 use Illuminate\Support\Facades\DB;
 
 class UpdateAdjustmentDocumentAction
@@ -33,14 +31,13 @@ class UpdateAdjustmentDocumentAction
             // Sync the lines: delete old ones, create new ones.
             $adjustmentDocument->lines()->delete();
 
-            $currencyCode = Currency::find($dto->currency_id)->code;
             $linesToCreate = [];
             foreach ($dto->lines as $lineDto) {
                 $linesToCreate[] = [
                     'product_id' => $lineDto->product_id,
                     'description' => $lineDto->description,
                     'quantity' => $lineDto->quantity,
-                    'unit_price' => Money::of($lineDto->unit_price, $currencyCode),
+                    'unit_price' => $lineDto->unit_price, // Already a Money object from DTO
                     'tax_id' => $lineDto->tax_id,
                     'account_id' => $lineDto->account_id,
                 ];

--- a/app/DataTransferObjects/Adjustments/CreateAdjustmentDocumentLineDTO.php
+++ b/app/DataTransferObjects/Adjustments/CreateAdjustmentDocumentLineDTO.php
@@ -2,12 +2,14 @@
 
 namespace App\DataTransferObjects\Adjustments;
 
+use Brick\Money\Money;
+
 class CreateAdjustmentDocumentLineDTO
 {
     public function __construct(
         public readonly string $description,
         public readonly float $quantity,
-        public readonly string $unit_price,
+        public readonly Money $unit_price,
         public readonly int $account_id,
         public readonly ?int $product_id,
         public readonly ?int $tax_id,

--- a/app/DataTransferObjects/Adjustments/UpdateAdjustmentDocumentLineDTO.php
+++ b/app/DataTransferObjects/Adjustments/UpdateAdjustmentDocumentLineDTO.php
@@ -2,12 +2,14 @@
 
 namespace App\DataTransferObjects\Adjustments;
 
+use Brick\Money\Money;
+
 class UpdateAdjustmentDocumentLineDTO
 {
     public function __construct(
         public readonly string $description,
         public readonly float $quantity,
-        public readonly string $unit_price,
+        public readonly Money $unit_price,
         public readonly int $account_id,
         public readonly ?int $product_id,
         public readonly ?int $tax_id,

--- a/app/Filament/Resources/AdjustmentDocumentResource.php
+++ b/app/Filament/Resources/AdjustmentDocumentResource.php
@@ -10,16 +10,18 @@ use App\Models\Invoice;
 use App\Models\Product;
 use Filament\Forms\Get;
 use Filament\Forms\Set;
-use App\Models\Currency;
+use App\Models\Company;
 use Filament\Forms\Form;
 use App\Models\VendorBill;
 use Filament\Tables\Table;
 use Filament\Resources\Resource;
 use App\Models\AdjustmentDocument;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Section;
 use App\Models\Account; // ADDED for Repeater schema
+use App\Filament\Forms\Components\MoneyInput;
 use App\Filament\Resources\AdjustmentDocumentResource\Pages;
-
+use Illuminate\Database\Eloquent\Builder;
 use App\Rules\NotInLockedPeriod;
 
 class AdjustmentDocumentResource extends Resource
@@ -42,92 +44,239 @@ class AdjustmentDocumentResource extends Resource
 
     public static function form(Form $form): Form
     {
+        $company = Company::first();
+
         return $form->schema([
-            Forms\Components\Group::make()->schema([
-                // ... (The top sections of the form are correct) ...
-                Forms\Components\Section::make(__('adjustment_document.section_details'))->schema([
-                    Forms\Components\Select::make('company_id')->relationship('company', 'name')->searchable()->preload()->required(),
-                    Forms\Components\Select::make('currency_id')->relationship('currency', 'name')->reactive()->required()
-                        ->disabled(fn (Get $get): bool => !empty($get('original_invoice_id')) || !empty($get('original_vendor_bill_id'))),
-                    Forms\Components\TextInput::make('reference_number')->required()->maxLength(255),
-                    Forms\Components\DatePicker::make('date')->required()->rules([new NotInLockedPeriod()]),
-                    Forms\Components\Select::make('type')->options(AdjustmentDocument::getTypes())->required(),
-                    Forms\Components\Textarea::make('reason')->required()->columnSpanFull(),
-                ])->columns(2),
-                Forms\Components\Section::make(__('adjustment_document.section_linking'))->schema([
-                    Forms\Components\Select::make('document_link_type')
-                        ->label(__('adjustment_document.document_to_adjust'))
-                        ->options(['invoice' => __('adjustment_document.original_invoice'), 'vendor_bill' => __('adjustment_document.original_vendor_bill')])
-                        ->reactive()
-                        ->afterStateUpdated(fn (Set $set) => [$set('original_invoice_id', null), $set('original_vendor_bill_id', null)])
-                        ->dehydrated(false)
-                        ->afterStateHydrated(function (Get $get, Set $set) {
-                            if ($get('original_invoice_id')) $set('document_link_type', 'invoice');
-                            elseif ($get('original_vendor_bill_id')) $set('document_link_type', 'vendor_bill');
-                        }),
-                    Forms\Components\Select::make('original_invoice_id')->searchable()->preload()->relationship('originalInvoice', 'invoice_number')->visible(fn (Get $get) => $get('document_link_type') === 'invoice')
-                        ->reactive()->afterStateUpdated(function ($state, Set $set) {
-                            if ($state) {
-                                $invoice = Invoice::find($state);
-                                $set('currency_id', $invoice?->currency_id);
-                            }
-                        }),
-                    Forms\Components\Select::make('original_vendor_bill_id')->searchable()->preload()->relationship('originalVendorBill', 'bill_reference')->visible(fn (Get $get) => $get('document_link_type') === 'vendor_bill')
-                        ->reactive()->afterStateUpdated(function ($state, Set $set) {
-                            if ($state) {
-                                $bill = VendorBill::find($state);
-                                $set('currency_id', $bill?->currency_id);
-                            }
-                        }),
-                ]),
-                // --- START OF REQUIRED CHANGES ---
-                Forms\Components\Section::make(__('adjustment_document.section_lines'))->schema([
-                    Repeater::make('lines')->schema([
-                        Forms\Components\Select::make('product_id')
-                            ->label(__('vendor_bill.product')) // Using existing translation key for consistency
+            Forms\Components\Grid::make(['lg' => 3])->schema([
+                Forms\Components\Group::make()->schema([
+                Section::make('Document Information')
+                    ->description('Basic information about the adjustment document')
+                    ->icon('heroicon-o-document-text')
+                    ->schema([
+                        Forms\Components\Grid::make(3)->schema([
+                            Forms\Components\Select::make('company_id')
+                                ->relationship('company', 'name')
+                                ->label('Company')
+                                ->required()
+                                ->live()
+                                ->default($company?->id)
+                                ->afterStateUpdated(function (callable $set, $state) {
+                                    $company = Company::find($state);
+                                    if ($company) {
+                                        $set('currency_id', $company->currency_id);
+                                    }
+                                })
+                                ->searchable()
+                                ->preload(),
+                            Forms\Components\Select::make('currency_id')
+                                ->relationship('currency', 'name')
+                                ->label('Currency')
+                                ->required()
+                                ->live()
+                                ->default($company?->currency_id)
+                                ->disabled(fn (Get $get): bool => !empty($get('original_invoice_id')) || !empty($get('original_vendor_bill_id')))
+                                ->searchable()
+                                ->preload(),
+                            Forms\Components\Select::make('type')
+                                ->label('Adjustment Type')
+                                ->options(AdjustmentDocument::getTypes())
+                                ->required()
+                                ->searchable(),
+                        ]),
+                        Forms\Components\Grid::make(2)->schema([
+                            Forms\Components\TextInput::make('reference_number')
+                                ->label('Reference Number')
+                                ->required()
+                                ->maxLength(255)
+                                ->placeholder('e.g., ADJ-2024-001'),
+                            Forms\Components\DatePicker::make('date')
+                                ->label('Adjustment Date')
+                                ->required()
+                                ->rules([new NotInLockedPeriod()])
+                                ->default(now())
+                                ->native(false),
+                        ]),
+                        Forms\Components\Textarea::make('reason')
+                            ->label('Reason for Adjustment')
+                            ->required()
+                            ->placeholder('Describe the reason for this adjustment...')
+                            ->rows(3)
+                            ->columnSpanFull(),
+                    ]),
+                Section::make('Link to Original Document')
+                    ->description('Optionally link this adjustment to an existing invoice or vendor bill')
+                    ->icon('heroicon-o-link')
+                    ->collapsible()
+                    ->collapsed()
+                    ->schema([
+                        Forms\Components\Select::make('document_link_type')
+                            ->label('Document Type to Adjust')
+                            ->options([
+                                'invoice' => 'Invoice',
+                                'vendor_bill' => 'Vendor Bill'
+                            ])
+                            ->reactive()
+                            ->afterStateUpdated(fn (Set $set) => [$set('original_invoice_id', null), $set('original_vendor_bill_id', null)])
+                            ->dehydrated(false)
+                            ->afterStateHydrated(function (Get $get, Set $set) {
+                                if ($get('original_invoice_id')) $set('document_link_type', 'invoice');
+                                elseif ($get('original_vendor_bill_id')) $set('document_link_type', 'vendor_bill');
+                            })
+                            ->placeholder('Select document type to link...'),
+                        Forms\Components\Select::make('original_invoice_id')
+                            ->label('Original Invoice')
                             ->searchable()
-                            ->getSearchResultsUsing(fn (string $search): array => Product::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
-                            ->getOptionLabelUsing(fn ($value): ?string => Product::find($value)?->name)
+                            ->preload()
+                            ->relationship('originalInvoice', 'invoice_number')
+                            ->visible(fn (Get $get) => $get('document_link_type') === 'invoice')
                             ->reactive()
                             ->afterStateUpdated(function ($state, Set $set) {
                                 if ($state) {
-                                    $product = Product::find($state);
-                                    if ($product) {
-                                        $set('description', $product->name);
-                                        $set('unit_price', $product->unit_price->getAmount()->toFloat());
-                                        $set('account_id', $product->income_account_id);
-                                    }
+                                    $invoice = Invoice::find($state);
+                                    $set('currency_id', $invoice?->currency_id);
                                 }
-                            })->columnSpan(2),
-                        Forms\Components\TextInput::make('description')->required()->columnSpan(3),
-                        Forms\Components\TextInput::make('quantity')->required()->numeric()->default(1)->reactive()->columnSpan(1),
-                        Forms\Components\TextInput::make('unit_price')->required()->numeric()->reactive()->columnSpan(2),
-                        Forms\Components\Select::make('tax_id')
-                            ->label(__('vendor_bill.tax')) // Using existing translation key for consistency
+                            })
+                            ->placeholder('Search for an invoice...'),
+                        Forms\Components\Select::make('original_vendor_bill_id')
+                            ->label('Original Vendor Bill')
                             ->searchable()
-                            ->getSearchResultsUsing(fn (string $search): array => Tax::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
-                            ->getOptionLabelUsing(fn ($value): ?string => Tax::find($value)?->name)
-                            ->reactive()->columnSpan(2),
-                        Forms\Components\Select::make('account_id')
-                            ->label(__('vendor_bill.expense_account')) // Using existing translation key for consistency
-                            ->searchable()
-                            ->getSearchResultsUsing(fn (string $search): array => Account::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
-                            ->getOptionLabelUsing(fn ($value): ?string => Account::find($value)?->name)
-                            ->required()->columnSpan(4),
-                    ])->columns(10)->columnSpanFull(),
-                ]),
-                // --- END OF REQUIRED CHANGES ---
-            ])->columnSpan(['lg' => 2]),
-            Forms\Components\Group::make()->schema([
-                Forms\Components\Section::make(__('adjustment_document.section_status'))->schema([
-                    Forms\Components\Select::make('status')->options(AdjustmentDocument::getStatuses())->disabled()->dehydrated(false),
-                ]),
-                Forms\Components\Section::make(__('adjustment_document.section_totals'))->schema([
-                    Forms\Components\TextInput::make('total_tax')->numeric()->readOnly()->prefix(fn (Get $get) => Currency::find($get('currency_id'))?->symbol ?? ''),
-                    Forms\Components\TextInput::make('total_amount')->numeric()->readOnly()->prefix(fn (Get $get) => Currency::find($get('currency_id'))?->symbol ?? ''),
-                ]),
-            ])->columnSpan(['lg' => 1]),
-        ])->columns(3);
+                            ->preload()
+                            ->relationship('originalVendorBill', 'bill_reference')
+                            ->visible(fn (Get $get) => $get('document_link_type') === 'vendor_bill')
+                            ->reactive()
+                            ->afterStateUpdated(function ($state, Set $set) {
+                                if ($state) {
+                                    $bill = VendorBill::find($state);
+                                    $set('currency_id', $bill?->currency_id);
+                                }
+                            })
+                            ->placeholder('Search for a vendor bill...'),
+                    ]),
+                ])->columnSpan(['lg' => 2]),
+                Forms\Components\Group::make()->schema([
+                    Section::make('Document Status')
+                        ->description('Current status and metadata')
+                        ->icon('heroicon-o-flag')
+                        ->schema([
+                            Forms\Components\Select::make('status')
+                                ->label('Status')
+                                ->options(AdjustmentDocument::getStatuses())
+                                ->disabled()
+                                ->dehydrated(false)
+                                ->default('draft'),
+                            Forms\Components\Placeholder::make('created_at')
+                                ->label('Created')
+                                ->content(fn (?AdjustmentDocument $record): string => $record?->created_at?->format('M j, Y g:i A') ?? 'Not saved yet')
+                                ->visible(fn (?AdjustmentDocument $record): bool => $record !== null),
+                            Forms\Components\Placeholder::make('updated_at')
+                                ->label('Last Modified')
+                                ->content(fn (?AdjustmentDocument $record): string => $record?->updated_at?->format('M j, Y g:i A') ?? 'Not saved yet')
+                                ->visible(fn (?AdjustmentDocument $record): bool => $record !== null),
+                        ]),
+                ])->columnSpan(['lg' => 1]),
+            ]),
+
+            // Full-width Line Items Section
+            Section::make('Line Items')
+                ->description('Add items to adjust in this document')
+                ->icon('heroicon-o-list-bullet')
+                ->schema([
+                    Repeater::make('lines')
+                        ->label('')
+                        ->live()
+                        ->reorderable(false)
+                        ->minItems(1)
+                        ->addActionLabel('+ Add Line')
+                        ->itemLabel(fn (array $state): ?string => $state['description'] ?? null)
+                        ->schema([
+                            Forms\Components\Grid::make([
+                                'default' => 1,
+                                'sm' => 2,
+                                'md' => 6,
+                                'lg' => 12,
+                            ])->schema([
+                                Forms\Components\Select::make('product_id')
+                                    ->label('Product')
+                                    ->searchable()
+                                    ->getSearchResultsUsing(fn(string $search): array => Product::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
+                                    ->getOptionLabelUsing(fn($value): ?string => Product::find($value)?->name)
+                                    ->reactive()
+                                    ->afterStateUpdated(function (callable $set, $state) {
+                                        if ($state) {
+                                            $product = Product::find($state);
+                                            if ($product) {
+                                                $set('description', $product->name);
+                                                $set('unit_price', $product->unit_price);
+                                                $set('account_id', $product->income_account_id);
+                                            }
+                                        }
+                                    })
+                                    ->placeholder('Select product...')
+                                    ->columnSpan([
+                                        'default' => 1,
+                                        'md' => 2,
+                                        'lg' => 2,
+                                    ]),
+                                Forms\Components\TextInput::make('description')
+                                    ->label('Description')
+                                    ->maxLength(255)
+                                    ->required()
+                                    ->placeholder('Item description')
+                                    ->columnSpan([
+                                        'default' => 1,
+                                        'md' => 2,
+                                        'lg' => 3,
+                                    ]),
+                                Forms\Components\TextInput::make('quantity')
+                                    ->label('Qty')
+                                    ->required()
+                                    ->numeric()
+                                    ->default(1)
+                                    ->minValue(0.01)
+                                    ->step(0.01)
+                                    ->columnSpan([
+                                        'default' => 1,
+                                        'md' => 1,
+                                        'lg' => 1,
+                                    ]),
+                                MoneyInput::make('unit_price')
+                                    ->label('Price')
+                                    ->currencyField('../../currency_id')
+                                    ->required()
+                                    ->columnSpan([
+                                        'default' => 1,
+                                        'md' => 1,
+                                        'lg' => 2,
+                                    ]),
+                                Forms\Components\Select::make('tax_id')
+                                    ->label('Tax')
+                                    ->searchable()
+                                    ->getSearchResultsUsing(fn(string $search): array => Tax::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
+                                    ->getOptionLabelUsing(fn($value): ?string => Tax::find($value)?->name)
+                                    ->placeholder('No tax')
+                                    ->columnSpan([
+                                        'default' => 1,
+                                        'md' => 1,
+                                        'lg' => 2,
+                                    ]),
+                                Forms\Components\Select::make('account_id')
+                                    ->label('Account')
+                                    ->searchable()
+                                    ->getSearchResultsUsing(fn(string $search): array => Account::where('name', 'like', "%{$search}%")->limit(50)->pluck('name', 'id')->toArray())
+                                    ->getOptionLabelUsing(fn($value): ?string => Account::find($value)?->name)
+                                    ->required()
+                                    ->placeholder('Select account...')
+                                    ->columnSpan([
+                                        'default' => 1,
+                                        'md' => 2,
+                                        'lg' => 2,
+                                    ]),
+                            ])
+                        ])
+                        ->columnSpanFull(),
+                ])
+                ->columnSpanFull(),
+        ]);
     }
 
     // table(), getRelations(), and getPages() methods are unchanged.
@@ -136,19 +285,80 @@ class AdjustmentDocumentResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('reference_number')->searchable()->sortable(),
-                Tables\Columns\TextColumn::make('company.name')->sortable(),
-                Tables\Columns\TextColumn::make('type')->searchable(),
-                Tables\Columns\TextColumn::make('date')->date()->sortable(),
-                Tables\Columns\TextColumn::make('total_amount')->money(fn($record) => $record->currency->code)->sortable(),
-                Tables\Columns\TextColumn::make('status')->badge()->color(fn(string $state): string => match ($state) {
-                    'Draft' => 'gray',
-                    'Posted' => 'success',
-                    default => 'gray',
-                })->searchable(),
+                Tables\Columns\TextColumn::make('reference_number')
+                    ->label('Reference')
+                    ->searchable()
+                    ->sortable()
+                    ->weight('medium')
+                    ->copyable()
+                    ->copyMessage('Reference copied!')
+                    ->icon('heroicon-o-hashtag'),
+                Tables\Columns\TextColumn::make('company.name')
+                    ->label('Company')
+                    ->sortable()
+                    ->icon('heroicon-o-building-office'),
+                Tables\Columns\TextColumn::make('type')
+                    ->label('Type')
+                    ->searchable()
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'credit_note' => 'success',
+                        'debit_note' => 'warning',
+                        default => 'gray',
+                    })
+                    ->formatStateUsing(fn (string $state): string => ucfirst(str_replace('_', ' ', $state))),
+                Tables\Columns\TextColumn::make('date')
+                    ->label('Date')
+                    ->date('M j, Y')
+                    ->sortable()
+                    ->icon('heroicon-o-calendar-days'),
+                Tables\Columns\TextColumn::make('total_amount')
+                    ->label('Amount')
+                    ->money(fn($record) => $record->currency->code)
+                    ->sortable()
+                    ->icon('heroicon-o-currency-dollar'),
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->color(fn(string $state): string => match ($state) {
+                        'Draft' => 'gray',
+                        'Posted' => 'success',
+                        'Cancelled' => 'danger',
+                        default => 'gray',
+                    })
+                    ->searchable(),
             ])
-            ->actions([Tables\Actions\EditAction::make()])
-            ->bulkActions([Tables\Actions\BulkActionGroup::make([Tables\Actions\DeleteBulkAction::make()])]);
+            ->defaultSort('created_at', 'desc')
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'Draft' => 'Draft',
+                        'Posted' => 'Posted',
+                        'Cancelled' => 'Cancelled',
+                    ])
+                    ->multiple(),
+                Tables\Filters\SelectFilter::make('type')
+                    ->options([
+                        'credit_note' => 'Credit Note',
+                        'debit_note' => 'Debit Note',
+                    ])
+                    ->multiple(),
+            ])
+            ->actions([
+                Tables\Actions\ViewAction::make()
+                    ->icon('heroicon-o-eye'),
+                Tables\Actions\EditAction::make()
+                    ->icon('heroicon-o-pencil-square'),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make()
+                        ->requiresConfirmation(),
+                ]),
+            ])
+            ->emptyStateHeading('No adjustment documents found')
+            ->emptyStateDescription('Create your first adjustment document to get started.')
+            ->emptyStateIcon('heroicon-o-document-text');
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/AdjustmentDocumentResource/Pages/CreateAdjustmentDocument.php
+++ b/app/Filament/Resources/AdjustmentDocumentResource/Pages/CreateAdjustmentDocument.php
@@ -6,6 +6,8 @@ namespace App\Filament\Resources\AdjustmentDocumentResource\Pages;
 // Add imports for Invoice and VendorBill
 use App\Models\Invoice;
 use App\Models\VendorBill;
+use App\Models\Currency;
+use Brick\Money\Money;
 use Illuminate\Validation\ValidationException;
 // Other use statements...
 use App\Actions\Adjustments\CreateAdjustmentDocumentAction;
@@ -56,12 +58,13 @@ class CreateAdjustmentDocument extends CreateRecord
     protected function handleRecordCreation(array $data): Model
     {
         // This method will now always receive a valid $data['currency_id']
+        $currency = Currency::find($data['currency_id']);
         $lineDTOs = [];
         foreach ($data['lines'] as $line) {
             $lineDTOs[] = new CreateAdjustmentDocumentLineDTO(
                 description: $line['description'],
                 quantity: $line['quantity'],
-                unit_price: $line['unit_price'],
+                unit_price: Money::of($line['unit_price'], $currency->code),
                 account_id: $line['account_id'],
                 product_id: $line['product_id'] ?? null,
                 tax_id: $line['tax_id'] ?? null

--- a/app/Filament/Resources/AdjustmentDocumentResource/Pages/EditAdjustmentDocument.php
+++ b/app/Filament/Resources/AdjustmentDocumentResource/Pages/EditAdjustmentDocument.php
@@ -6,6 +6,8 @@ namespace App\Filament\Resources\AdjustmentDocumentResource\Pages;
 // Add these imports
 use App\Models\Invoice;
 use App\Models\VendorBill;
+use App\Models\Currency;
+use Brick\Money\Money;
 use Illuminate\Validation\ValidationException;
 
 // Other use statements...
@@ -46,7 +48,7 @@ class EditAdjustmentDocument extends EditRecord
             Actions\DeleteAction::make(),
         ];
     }
-    
+
     // --- START OF THE FIX ---
     protected function mutateFormDataBeforeSave(array $data): array
     {
@@ -70,7 +72,7 @@ class EditAdjustmentDocument extends EditRecord
                 'data.currency_id' => __('validation.required', ['attribute' => 'currency']),
             ]);
         }
-        
+
         // 4. Inject the now-guaranteed currency_id into the line items.
         $parentCurrencyId = $data['currency_id'];
         if (isset($data['lines'])) {
@@ -89,34 +91,33 @@ class EditAdjustmentDocument extends EditRecord
     protected function mutateFormDataBeforeFill(array $data): array
     {
         $this->record->loadMissing('lines');
-        
+
+        // Keep Money objects for MoneyInput components
         $linesData = $this->record->lines->map(function ($line) {
             return [
                 'product_id' => $line->product_id,
                 'description' => $line->description,
                 'quantity' => $line->quantity,
-                'unit_price' => $line->unit_price?->getAmount()->toFloat(),
+                'unit_price' => $line->unit_price, // Keep as Money object
                 'tax_id' => $line->tax_id,
                 'account_id' => $line->account_id,
             ];
         })->toArray();
-        
+
         $data['lines'] = $linesData;
-        $data['total_amount'] = $this->record->total_amount?->getAmount()->toFloat();
-        $data['total_tax'] = $this->record->total_tax?->getAmount()->toFloat();
-        
         return $data;
     }
 
     protected function handleRecordUpdate(Model $record, array $data): Model
     {
         // This method will now always receive a valid $data['currency_id']
+        $currency = Currency::find($data['currency_id']);
         $lineDTOs = [];
         foreach ($data['lines'] as $line) {
             $lineDTOs[] = new UpdateAdjustmentDocumentLineDTO(
                 description: $line['description'],
                 quantity: $line['quantity'],
-                unit_price: $line['unit_price'],
+                unit_price: Money::of($line['unit_price'], $currency->code),
                 account_id: $line['account_id'],
                 product_id: $line['product_id'] ?? null,
                 tax_id: $line['tax_id'] ?? null

--- a/app/Models/AdjustmentDocumentLine.php
+++ b/app/Models/AdjustmentDocumentLine.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use App\Casts\MoneyCast;
 use App\Observers\AdjustmentDocumentLineObserver;
+use Brick\Money\Money;
+use Brick\Math\RoundingMode;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -35,6 +37,37 @@ class AdjustmentDocumentLine extends Model
         'subtotal' => MoneyCast::class,
         'total_line_tax' => MoneyCast::class,
     ];
+
+    protected static function booted(): void
+    {
+        static::saving(function (self $line) {
+            $line->calculateLineTotals();
+        });
+    }
+
+    public function calculateLineTotals(): void
+    {
+        $currency = $this->adjustmentDocument->currency;
+        $quantity = $this->quantity;
+
+        // If unit_price is already a Money object, use it. Otherwise, create it from the numeric value.
+        $unitPrice = $this->unit_price instanceof Money
+            ? $this->unit_price
+            : Money::of($this->unit_price, $currency->code);
+
+        $subtotal = $unitPrice->multipliedBy($quantity, RoundingMode::HALF_UP);
+        $this->subtotal = $subtotal;
+
+        $totalLineTax = Money::of(0, $currency->code);
+        if ($this->tax_id) {
+            $tax = Tax::find($this->tax_id);
+            if ($tax) {
+                // NOTE: The rate in Tax model is a float (e.g., 0.10 for 10%)
+                $totalLineTax = $subtotal->multipliedBy($tax->rate, RoundingMode::HALF_UP);
+            }
+        }
+        $this->total_line_tax = $totalLineTax;
+    }
 
     public function adjustmentDocument(): BelongsTo
     {

--- a/app/Observers/AdjustmentDocumentLineObserver.php
+++ b/app/Observers/AdjustmentDocumentLineObserver.php
@@ -1,59 +1,38 @@
 <?php
-// in app/Observers/AdjustmentDocumentLineObserver.php
 
 namespace App\Observers;
 
 use App\Models\AdjustmentDocumentLine;
-use App\Models\Tax;
-use Brick\Money\Money;
 
 class AdjustmentDocumentLineObserver
 {
-    public function creating(AdjustmentDocumentLine $line): void
+
+    /**
+     * Handle the AdjustmentDocumentLine "saved" event.
+     * This is triggered on both creation and update.
+     */
+    public function saved(AdjustmentDocumentLine $adjustmentDocumentLine): void
     {
-        $this->calculateLineTotals($line);
+        $this->updateParentAdjustmentDocumentTotals($adjustmentDocumentLine);
     }
 
-    public function updating(AdjustmentDocumentLine $line): void
+    /**
+     * Handle the AdjustmentDocumentLine "deleted" event.
+     */
+    public function deleted(AdjustmentDocumentLine $adjustmentDocumentLine): void
     {
-        $this->calculateLineTotals($line);
+        $this->updateParentAdjustmentDocumentTotals($adjustmentDocumentLine);
     }
 
-    public function saved(AdjustmentDocumentLine $line): void
+    /**
+     * Recalculate and save the totals on the parent AdjustmentDocument.
+     */
+    protected function updateParentAdjustmentDocumentTotals(AdjustmentDocumentLine $adjustmentDocumentLine): void
     {
-        $line->adjustmentDocument->calculateTotalsFromLines();
-        $line->adjustmentDocument->save();
-    }
-
-    public function deleted(AdjustmentDocumentLine $line): void
-    {
-        // Reload the lines relationship on the parent before recalculating
-        $line->adjustmentDocument->load('lines');
-        $line->adjustmentDocument->calculateTotalsFromLines();
-        $line->adjustmentDocument->save();
-    }
-
-    protected function calculateLineTotals(AdjustmentDocumentLine $line): void
-    {
-        $currency = $line->adjustmentDocument->currency;
-        $quantity = $line->quantity;
-
-        // If unit_price is already a Money object, use it. Otherwise, create it from the numeric value.
-        $unitPrice = $line->unit_price instanceof Money
-            ? $line->unit_price
-            : Money::of($line->unit_price, $currency->code);
-
-        $subtotal = $unitPrice->multipliedBy($quantity);
-        $line->subtotal = $subtotal;
-
-        $totalLineTax = Money::of(0, $currency->code);
-        if ($line->tax_id) {
-            $tax = Tax::find($line->tax_id);
-            if ($tax) {
-                // Ensure the tax calculation also uses the correct currency context.
-                $totalLineTax = $subtotal->multipliedBy($tax->rate);
-            }
+        $adjustmentDocument = $adjustmentDocumentLine->adjustmentDocument;
+        if ($adjustmentDocument) {
+            $adjustmentDocument->calculateTotalsFromLines();
+            $adjustmentDocument->saveQuietly();
         }
-        $line->total_line_tax = $totalLineTax;
     }
 }

--- a/database/factories/AdjustmentDocumentFactory.php
+++ b/database/factories/AdjustmentDocumentFactory.php
@@ -21,17 +21,61 @@ class AdjustmentDocumentFactory extends Factory
     {
         return [
             'company_id' => Company::factory(),
-            'currency_id' => fn(array $attributes) => Company::find($attributes['company_id'])->currency_id,
+            'currency_id' => function (array $attributes) {
+                return Company::find($attributes['company_id'])->currency_id;
+            },
             'original_invoice_id' => null,
             'original_vendor_bill_id' => null,
             'type' => $this->faker->randomElement(['Credit Note', 'Debit Note', 'Miscellaneous Adjustment']),
             'date' => $this->faker->date(),
             'reference_number' => $this->faker->unique()->bothify('ADJ-#####'),
-            'total_amount' => Money::of($this->faker->randomFloat(2, 100, 10000), 'IQD'),
-            'total_tax' => Money::of($this->faker->randomFloat(2, 0, 2000), 'IQD'),
+            'total_amount' => function (array $attributes) {
+                $currency = Currency::find($attributes['currency_id']);
+                return Money::of($this->faker->randomFloat(2, 100, 10000), $currency->code);
+            },
+            'total_tax' => function (array $attributes) {
+                $currency = Currency::find($attributes['currency_id']);
+                return Money::of($this->faker->randomFloat(2, 0, 2000), $currency->code);
+            },
             'reason' => $this->faker->sentence(),
             'status' => $this->faker->randomElement(['Draft', 'Posted']),
             'journal_entry_id' => null,
         ];
+    }
+
+    public function draft(): self
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'Draft',
+            'posted_at' => null,
+            'journal_entry_id' => null,
+        ]);
+    }
+
+    public function posted(): self
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'status' => 'Posted',
+                'posted_at' => now(),
+                'journal_entry_id' => \App\Models\JournalEntry::factory()->create([
+                    'company_id' => $attributes['company_id'],
+                ])->id,
+            ];
+        });
+    }
+
+    public function withLines(int $count = 1): self
+    {
+        return $this->afterCreating(function (\App\Models\AdjustmentDocument $adjustmentDocument) use ($count) {
+            \App\Models\AdjustmentDocumentLine::factory()->count($count)->create([
+                'adjustment_document_id' => $adjustmentDocument->id,
+            ]);
+
+            // Recalculate totals from lines
+            $adjustmentDocument->refresh();
+            $adjustmentDocument->calculateTotalsFromLines();
+            $adjustmentDocument->saveQuietly();
+        });
     }
 }

--- a/database/factories/AdjustmentDocumentLineFactory.php
+++ b/database/factories/AdjustmentDocumentLineFactory.php
@@ -6,7 +6,6 @@ use App\Models\Tax;
 use Brick\Money\Money;
 use App\Models\Account;
 use App\Models\Product;
-use App\Models\Currency;
 use App\Models\AdjustmentDocument;
 use App\Models\AdjustmentDocumentLine;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -22,10 +21,13 @@ class AdjustmentDocumentLineFactory extends Factory
             'product_id' => Product::factory(),
             'description' => $this->faker->sentence,
             'quantity' => $this->faker->numberBetween(1, 10),
-            'unit_price' => Money::of($this->faker->randomFloat(2, 10, 100), 'USD'),
+            'unit_price' => function (array $attributes) {
+                $adjustmentDocument = AdjustmentDocument::find($attributes['adjustment_document_id']);
+                $currency = $adjustmentDocument->currency;
+                return Money::of($this->faker->randomFloat(2, 10, 100), $currency->code);
+            },
             'tax_id' => Tax::factory(),
-            'subtotal' => Money::of($this->faker->randomFloat(2, 100, 10000), 'USD'),
-            'total_line_tax' => Money::of($this->faker->randomFloat(2, 0, 100), 'USD'),
+            // Don't set subtotal and total_line_tax - let the model calculate them
             'account_id' => Account::factory(),
         ];
     }

--- a/tests/Feature/Adjustments/AdjustmentDocumentWithLinesTest.php
+++ b/tests/Feature/Adjustments/AdjustmentDocumentWithLinesTest.php
@@ -71,7 +71,7 @@ test('create adjustment document action correctly creates document with lines', 
         new CreateAdjustmentDocumentLineDTO(
             description: 'Service A refund',
             quantity: 1,
-            unit_price: '200.00',
+            unit_price: Money::of('200.00', $currencyCode),
             account_id: $account->id,
             tax_id: $tax->id,
             product_id: null
@@ -79,7 +79,7 @@ test('create adjustment document action correctly creates document with lines', 
         new CreateAdjustmentDocumentLineDTO(
             description: 'Shipping fee refund',
             quantity: 1,
-            unit_price: '15.00',
+            unit_price: Money::of('15.00', $currencyCode),
             account_id: $account->id,
             tax_id: null,
             product_id: null

--- a/tests/Feature/Filament/AdjustmentDocumentResourceTest.php
+++ b/tests/Feature/Filament/AdjustmentDocumentResourceTest.php
@@ -1,0 +1,197 @@
+<?php
+
+use App\Filament\Resources\AdjustmentDocumentResource;
+use App\Models\Product;
+use App\Models\AdjustmentDocument;
+use App\Models\Account;
+use App\Models\Tax;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Traits\WithConfiguredCompany;
+use function Pest\Livewire\livewire;
+
+uses(RefreshDatabase::class, WithConfiguredCompany::class);
+
+beforeEach(function () {
+    $this->setupWithConfiguredCompany();
+    // Acting as the authenticated user
+    $this->actingAs($this->user);
+});
+
+it('can render the list page', function () {
+    $this->get(AdjustmentDocumentResource::getUrl('index'))->assertSuccessful();
+});
+
+it('can render the create page', function () {
+    $this->get(AdjustmentDocumentResource::getUrl('create'))->assertSuccessful();
+});
+
+it('can create an adjustment document', function () {
+    /** @var \App\Models\Account $account */
+    $account = Account::factory()->create([
+        'company_id' => $this->company->id,
+    ]);
+
+    /** @var \App\Models\Product $product */
+    $product = Product::factory()->create([
+        'company_id' => $this->company->id,
+        'name' => 'Test Product Line', // Set a specific name to match the database assertion
+        'unit_price' => \Brick\Money\Money::of(100, $this->company->currency->code), // Set a specific price for predictable total
+    ]);
+
+    livewire(AdjustmentDocumentResource\Pages\CreateAdjustmentDocument::class)
+        ->fillForm([
+            'company_id' => $this->company->id,
+            'currency_id' => $this->company->currency_id,
+            'reference_number' => 'Test Adjustment Ref',
+            'date' => now()->format('Y-m-d'),
+            'type' => AdjustmentDocument::TYPE_CREDIT_NOTE,
+            'reason' => 'Test adjustment reason',
+        ])
+        ->set('data.lines', [
+            [
+                'product_id' => $product->id,
+                'description' => 'Test Product Line',
+                'quantity' => 2,
+                'unit_price' => $product->unit_price->getAmount()->toFloat(),
+                'account_id' => $account->id,
+                'tax_id' => null,
+            ],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('adjustment_documents', [
+        'reference_number' => 'Test Adjustment Ref',
+        'status' => AdjustmentDocument::STATUS_DRAFT,
+    ]);
+
+    $this->assertDatabaseHas('adjustment_document_lines', [
+        'product_id' => $product->id,
+        'description' => 'Test Product Line',
+        'quantity' => 2,
+    ]);
+
+    $adjustmentDocument = AdjustmentDocument::first();
+    $this->assertEquals(200, $adjustmentDocument->total_amount->getAmount()->toFloat());
+});
+
+it('can validate input on create', function () {
+    livewire(AdjustmentDocumentResource\Pages\CreateAdjustmentDocument::class)
+        ->fillForm([
+            'reference_number' => null,
+            'date' => null,
+            'type' => null,
+            'reason' => null,
+            'lines' => [],
+        ])
+        ->call('create')
+        ->assertHasFormErrors([
+            'reference_number' => 'required',
+            'date' => 'required',
+            'type' => 'required',
+            'reason' => 'required',
+            'lines' => 'min',
+        ]);
+});
+
+it('can render the edit page', function () {
+    $adjustmentDocument = AdjustmentDocument::factory()->create([
+        'company_id' => $this->company->id,
+    ]);
+
+    $this->get(AdjustmentDocumentResource::getUrl('edit', ['record' => $adjustmentDocument]))
+        ->assertSuccessful();
+});
+
+it('can edit an adjustment document', function () {
+    /** @var \App\Models\Account $account */
+    $account = Account::factory()->create([
+        'company_id' => $this->company->id,
+    ]);
+
+    $adjustmentDocument = AdjustmentDocument::factory()->create([
+        'company_id' => $this->company->id,
+        'currency_id' => $this->company->currency_id,
+        'reference_number' => 'Old Ref',
+        'status' => AdjustmentDocument::STATUS_DRAFT,
+    ]);
+
+    // Create a line manually to ensure proper setup
+    $adjustmentDocument->lines()->create([
+        'description' => 'Test Line',
+        'quantity' => 1,
+        'unit_price' => \Brick\Money\Money::of(100, $this->company->currency->code),
+        'account_id' => $account->id,
+        'tax_id' => null,
+    ]);
+
+    // The mutateFormDataBeforeFill method in EditAdjustmentDocument already handles
+    // the conversion of line data with Money objects properly, so we don't need to override it
+    livewire(AdjustmentDocumentResource\Pages\EditAdjustmentDocument::class, [
+        'record' => $adjustmentDocument->getRouteKey(),
+    ])
+        ->fillForm([
+            'reference_number' => 'New Ref',
+            'reason' => 'Updated reason',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('adjustment_documents', [
+        'id' => $adjustmentDocument->id,
+        'reference_number' => 'New Ref',
+        'reason' => 'Updated reason',
+    ]);
+});
+
+it('can post an adjustment document', function () {
+    /** @var \App\Models\Account $account */
+    $account = Account::factory()->create([
+        'company_id' => $this->company->id,
+    ]);
+
+    $adjustmentDocument = AdjustmentDocument::factory()->create([
+        'company_id' => $this->company->id,
+        'currency_id' => $this->company->currency_id,
+        'status' => AdjustmentDocument::STATUS_DRAFT,
+    ]);
+
+    // Create a line manually to ensure proper setup
+    $adjustmentDocument->lines()->create([
+        'description' => 'Test Line',
+        'quantity' => 1,
+        'unit_price' => \Brick\Money\Money::of(100, $this->company->currency->code),
+        'account_id' => $account->id,
+        'tax_id' => null,
+    ]);
+
+    livewire(AdjustmentDocumentResource\Pages\EditAdjustmentDocument::class, [
+        'record' => $adjustmentDocument->getRouteKey(),
+    ])
+        ->callAction('post')
+        ->assertHasNoErrors();
+
+    $adjustmentDocument->refresh();
+    expect($adjustmentDocument->status)->toBe(AdjustmentDocument::STATUS_POSTED);
+});
+
+// Note: resetToDraft action doesn't exist in current implementation
+// This test is commented out until the action is implemented
+// it('can reset an adjustment document to draft', function () {
+//     $adjustmentDocument = AdjustmentDocument::factory()->create([
+//         'company_id' => $this->company->id,
+//         'status' => AdjustmentDocument::STATUS_POSTED,
+//         'posted_at' => now(),
+//     ]);
+
+//     livewire(AdjustmentDocumentResource\Pages\EditAdjustmentDocument::class, [
+//         'record' => $adjustmentDocument->getRouteKey(),
+//     ])
+//         ->callAction('resetToDraft', data: [
+//             'reason' => 'Test reason',
+//         ])
+//         ->assertHasNoErrors();
+
+//     $adjustmentDocument->refresh();
+//     expect($adjustmentDocument->status)->toBe(AdjustmentDocument::STATUS_DRAFT);
+// });


### PR DESCRIPTION
- Updated CreateAdjustmentDocumentAction and UpdateAdjustmentDocumentAction to accept Money objects for unit prices.
- Modified CreateAdjustmentDocumentLineDTO and UpdateAdjustmentDocumentLineDTO to use Money type for unit_price.
- Enhanced AdjustmentDocumentResource form to handle Money inputs correctly.
- Adjusted factory methods for AdjustmentDocument and AdjustmentDocumentLine to generate Money objects based on currency.
- Implemented calculation of line totals within the AdjustmentDocumentLine model.
- Updated tests to ensure proper handling of Money objects in adjustment documents and lines.